### PR TITLE
[Update] To account for all 0 in FID

### DIFF
--- a/R/parse.pheno.covar.R
+++ b/R/parse.pheno.covar.R
@@ -1,6 +1,5 @@
 parse.pheno.covar <- function(pheno, covar, parsed, trace=0) {
   #' @keywords internal
-
   fam <- parsed[['fam']]
   keep <- parsed$keep
   # keep <- NULL
@@ -37,7 +36,7 @@ parse.pheno.covar <- function(pheno, covar, parsed, trace=0) {
     colnames(pheno.df)[3] <- "pheno"
     rownames(pheno) <- paste(pheno$FID, pheno$IID, sep="_")
     keep <- update.keep(keep, rownames(fam) %in% rownames(pheno))
-    Pheno <- pheno[,3]
+    Pheno <- as.data.frame(pheno)[,3]
     names(Pheno) <- rownames(pheno)
   } else {
     if(!is.null(pheno)) {
@@ -57,6 +56,7 @@ parse.pheno.covar <- function(pheno, covar, parsed, trace=0) {
   }
   if(is.data.frame(covar) & all(colnames(covar)[1:2] == c("FID", "IID"))) {
     user.covar <- TRUE
+    covar <- as.data.frame(covar)
     colnames <- colnames(covar) 
     if(is.null(fam)) fam <- read.table2(parsed$famfile)
     rownames(fam) <- paste(fam$V1, fam$V2, sep="_")

--- a/R/parseselect.R
+++ b/R/parseselect.R
@@ -139,7 +139,8 @@ parseselect <- function(bfile, extract=NULL, exclude=NULL,
         stopifnot(ncol(keep)==2)
         fam <- read.table2(famfile)
         famID <- paste(fam[,1], fam[,2], sep=".")
-        keepID <- paste(keep[,1], keep[,2], sep=".")
+        keep <- as.data.table(keep)
+        keepID <- keep[, ID:=do.call(paste, c(.SD, sep=":")),.SDcols=c(1:2)][,ID]
         keep <- famID %in% keepID
         if(order.important) {
           if(!all(famID[keep] == keepID)) {
@@ -167,7 +168,8 @@ parseselect <- function(bfile, extract=NULL, exclude=NULL,
         stopifnot(ncol(remove)==2)
         if(is.null(fam)) fam <- read.table2(famfile)
         famID <- paste(fam[,1], fam[,2], sep=".")
-        removeID <- paste(remove[,1], remove[,2], sep=".")
+        remove <- as.data.table(remove)
+        removeID <- remove[, ID:=do.call(paste, c(.SD, sep=":")),.SDcols=c(1:2)][,ID]
         remove <- famID %in% removeID
       } else {
         stop("I don't know what to do with this type of input for remove")


### PR DESCRIPTION
It's just a simple change to use the data.table function. The original paste will fail for inputs with FID containing only 0.

E.g.
```
IID <- replicate(1000,paste(sample(LETTERS,6,  replace=T), sep="", collapse = ""))
test <- data.frame(FID=0, IID=names)
keep <- paste(test[,1], test[,2], sep=".")
keep.by.id <- paste(test$FID, test$IID, sep=".")
print(sum(keep%in%keep.by.id))
```

And you will get 0. 

As we don't know if the user input contain FID or IID, we will need some other way to handle this