### PR TITLE
fixed parseselect to safely accept other data.frame-like objects; updated docs

### DIFF
--- a/R/parseselect.R
+++ b/R/parseselect.R
@@ -1,12 +1,14 @@
 #' @title Parse the keep/remove/extract/exclude/chr options
-#' @details \code{keep}, \code{remove} could take one of three 
-#' formats: (1) A logical vector indicating which indivduals to keep/remove, 
-#' (2) A \code{data.frame} with two columns giving the FID and IID of the indivdiuals
-#' to keep/remove (matching those in the .fam file), or (3) a character scalar giving 
-#' the text file with the FID/IID. Note that these files should have no headers. 
-#' Likewise \code{extract}, \code{exclude} can also take one of the three formats,
-#' except with the role of the FID/IID data.frame replaced with a character vector of 
-#' SNP ids (matching those in the .bim file). 
+#' @details \code{keep} and \code{remove} can take one of three
+#' formats:
+#' 1. A logical vector indicating which indivduals to keep/remove,
+#'
+#' 2. A \code{data.frame} with two columns giving the FID and IID of the indivdiuals to keep/remove (matching those in the .fam file), or
+#' 3. A character scalar giving the text file with the FID/IID.
+#'
+#' Note that these files should not contain headers.
+#'
+#' \code{extract} and \code{exclude} can be of format type __(1)__ or __(3)__ describe above, or a character vector of SNP ids (matching those in the .bim file).
 
 #' @param bfile plink file stem
 #' @param extract SNPs to extract
@@ -14,19 +16,23 @@
 #' @param keep samples to keep
 #' @param remove samples to remove
 #' @param chr a vector of chromosomes
+#' @param export Logical. Whether to include the \code{bim} and/or \code{fam} data in the returned object.
+#' @param order.important Logical. Whether to strictly enforce that the order of \code{extract} and/or \code{keep} must match with \code{bim} or \code{fam}, respectively.
+#'
+#' @md
 #' @export
-parseselect <- function(bfile, extract=NULL, exclude=NULL, 
-                        keep=NULL, remove=NULL, chr=NULL, 
+parseselect <- function(bfile, extract=NULL, exclude=NULL,
+                        keep=NULL, remove=NULL, chr=NULL,
                         export=FALSE, order.important=FALSE) {
 
-  #### Introduced for parsing multiple bfiles ####  
+  #### Introduced for parsing multiple bfiles ####
   if(length(bfile) > 1) {
     if(!is.null(chr) || !is.null(extract) || !is.null(exclude)) {
       stop("bfile cannot be a vector if we are parsing extract/exclude/chr. yet.")
     }
     bfile <- bfile[1]
   }
-  
+
   #### Checks ####
   stopifnot(is.character(bfile) && length(bfile) == 1)
   bedfile <- paste0(bfile, ".bed")
@@ -35,11 +41,11 @@ parseselect <- function(bfile, extract=NULL, exclude=NULL,
   stopifnot(file.exists(bedfile))
   stopifnot(file.exists(bimfile))
   stopifnot(file.exists(famfile))
-  
+
   if(grepl("^~", bfile)) {
     stop("Don't use '~' as a shortcut for the home directory.")
   }
-  
+
   p <- P <- ncol.bfile(bfile)
   n <- N <- nrow.bfile(bfile)
   bim <- NULL
@@ -51,7 +57,7 @@ parseselect <- function(bfile, extract=NULL, exclude=NULL,
       stopifnot(length(extract) == P)
     } else {
       if(is.null(attr(extract, "not.a.file", exact=T))) {
-        if(is.character(extract) && length(extract) == 1) {
+        if(is.character(extract) && length(extract) == 1 && file.exists(extract)) {
           ### I'm interpreting this as a filename
           SNPs <- read.table2(extract)
           stopifnot(ncol(SNPs)==1)
@@ -73,17 +79,17 @@ parseselect <- function(bfile, extract=NULL, exclude=NULL,
         stop("I don't know what to do with this type of input for extract")
       }
     }
-    
+
     p <- sum(extract)
   }
-  
+
   #### exclude ####
   if(!is.null(exclude)) {
     if(is.logical(exclude)) {
       stopifnot(length(exclude) == P)
     } else {
       if(is.null(attr(exclude, "not.a.file", exact=T))) {
-        if(is.character(exclude) && length(exclude) == 1) {
+        if(is.character(exclude) && length(exclude) == 1 && file.exists(exclude)) {
           ### I'm interpreting this as a filename
           SNPs <- read.table2(exclude)
           stopifnot(ncol(SNPs)==1)
@@ -99,43 +105,44 @@ parseselect <- function(bfile, extract=NULL, exclude=NULL,
       } else {
         stop("I don't know what to do with this type of input for exclude")
       }
-      
+
     }
-    
-    if(is.null(extract)) extract <- !exclude else 
+
+    if(is.null(extract)) extract <- !exclude else
       extract <- extract & !exclude
-    
+
     p <- sum(extract)
   }
-  
+
   #### chr ####
   if(!is.null(chr)) {
 
     stopifnot(is.vector(chr))
     chr <- as.character(chr)
-    
+
     if(is.null(bim)) bim <- read.table2(bimfile)
     bimchr <- bim$V1
     bimchr[bimchr==""]
     extract.chr <- bim$V1 %in% chr
 
-    if(is.null(extract)) extract <- extract.chr else 
+    if(is.null(extract)) extract <- extract.chr else
       extract <- extract & extract.chr
-    
+
     p <- sum(extract)
-    
+
   }
-  
+
   #### keep ####
   if(!is.null(keep)) {
     if(is.logical(keep)) {
       stopifnot(length(keep) == N)
     } else {
-      if(is.character(keep) && length(keep) == 1) {
+      if(is.character(keep) && length(keep) == 1 && file.exists(keep)) {
         ### I'm interpreting this as a filename
         keep <- read.table2(keep)
       }
-      if(is.data.frame(keep)) {
+      if(inherits(keep, "data.frame")) {
+        keep <- as.data.frame(keep)
         stopifnot(ncol(keep)==2)
         fam <- read.table2(famfile)
         famID <- paste(fam[,1], fam[,2], sep=".")
@@ -149,21 +156,22 @@ parseselect <- function(bfile, extract=NULL, exclude=NULL,
       } else {
         stop("I don't know what to do with this type of input for keep")
       }
-      
+
     }
     n <- sum(keep)
   }
-  
+
   #### remove ####
   if(!is.null(remove)) {
     if(is.logical(remove)) {
       stopifnot(length(remove) == N)
     } else {
-      if(is.character(remove) && length(remove) == 1) {
+      if(is.character(remove) && length(remove) == 1 && file.exists(remove)) {
         ### I'm interpreting this as a filename
         remove <- read.table2(remove)
       }
-      if(is.data.frame(remove)) {
+      if(inherits(remove, "data.frame")) {
+        remove <- as.data.frame(remove)
         stopifnot(ncol(remove)==2)
         if(is.null(fam)) fam <- read.table2(famfile)
         famID <- paste(fam[,1], fam[,2], sep=".")
@@ -173,33 +181,38 @@ parseselect <- function(bfile, extract=NULL, exclude=NULL,
         stop("I don't know what to do with this type of input for remove")
       }
     }
-    
-    if(is.null(keep)) keep <- !remove else 
+
+    if(is.null(keep)) keep <- !remove else
       keep <- keep & !remove
-    
+
     n <- sum(keep)
   }
 
   if(n==0) stop("No individuals left after keep/remove! Make sure the FID/IID are correct.")
   if(p==0) stop("No SNPs left after extract/exclude/chr! Make sure the SNP ids are correct.")
-  
+
   if(!export) {
-    return(list(keep=keep, extract=extract, 
-                N=N, P=P, n=n, p=p, bfile=bfile, 
-                bimfile=bimfile, famfile=famfile, 
+    return(list(keep=keep, extract=extract,
+                N=N, P=P, n=n, p=p, bfile=bfile,
+                bimfile=bimfile, famfile=famfile,
                 bim=NULL, fam=NULL))
   } else {
-    return(list(keep=keep, extract=extract, 
-                N=N, P=P, n=n, p=p, bfile=bfile, 
-                bimfile=bimfile, famfile=famfile, 
+    return(list(keep=keep, extract=extract,
+                N=N, P=P, n=n, p=p, bfile=bfile,
+                bimfile=bimfile, famfile=famfile,
                 bim=bim, fam=fam))
   }
-  #' @return a list with
+  #' @return A list containing:
   #' \item{keep}{Either NULL or a logical vector of which individuals to keep}
   #' \item{extract}{Either NULL or a logical vector of which SNPs to extract}
   #' \item{N}{Number of rows in the PLINK bfile}
   #' \item{P}{Number of columns in the PLINK bfile}
   #' \item{n}{Number of rows in the PLINK bfile after keep}
   #' \item{p}{Number of columns in the PLINK bfile after extract}
-  
+  #' \item{bfile}{File path to bfile stub}
+  #' \item{bimfile}{File path to bim file}
+  #' \item{famfile}{File path to fam file}
+  #' \item{bim}{Either \code{NULL} or a data frame of bim data}
+  #' \item{fam}{Either \code{NULL} or a data frame of fam data}
+
 }

--- a/man/parseselect.Rd
+++ b/man/parseselect.Rd
@@ -4,9 +4,16 @@
 \alias{parseselect}
 \title{Parse the keep/remove/extract/exclude/chr options}
 \usage{
-parseselect(bfile, extract = NULL, exclude = NULL, keep = NULL,
-  remove = NULL, chr = NULL, export = FALSE,
-  order.important = FALSE)
+parseselect(
+  bfile,
+  extract = NULL,
+  exclude = NULL,
+  keep = NULL,
+  remove = NULL,
+  chr = NULL,
+  export = FALSE,
+  order.important = FALSE
+)
 }
 \arguments{
 \item{bfile}{plink file stem}
@@ -20,26 +27,38 @@ parseselect(bfile, extract = NULL, exclude = NULL, keep = NULL,
 \item{remove}{samples to remove}
 
 \item{chr}{a vector of chromosomes}
+
+\item{export}{Logical. Whether to include the \code{bim} and/or \code{fam} data in the returned object.}
+
+\item{order.important}{Logical. Whether to strictly enforce that the order of \code{extract} and/or \code{keep} must match with \code{bim} or \code{fam}, respectively.}
 }
 \value{
-a list with
+A list containing:
 \item{keep}{Either NULL or a logical vector of which individuals to keep}
 \item{extract}{Either NULL or a logical vector of which SNPs to extract}
 \item{N}{Number of rows in the PLINK bfile}
 \item{P}{Number of columns in the PLINK bfile}
 \item{n}{Number of rows in the PLINK bfile after keep}
 \item{p}{Number of columns in the PLINK bfile after extract}
+\item{bfile}{File path to bfile stub}
+\item{bimfile}{File path to bim file}
+\item{famfile}{File path to fam file}
+\item{bim}{Either \code{NULL} or a data frame of bim data}
+\item{fam}{Either \code{NULL} or a data frame of fam data}
 }
 \description{
 Parse the keep/remove/extract/exclude/chr options
 }
 \details{
-\code{keep}, \code{remove} could take one of three 
-formats: (1) A logical vector indicating which indivduals to keep/remove, 
-(2) A \code{data.frame} with two columns giving the FID and IID of the indivdiuals
-to keep/remove (matching those in the .fam file), or (3) a character scalar giving 
-the text file with the FID/IID. Note that these files should have no headers. 
-Likewise \code{extract}, \code{exclude} can also take one of the three formats,
-except with the role of the FID/IID data.frame replaced with a character vector of 
-SNP ids (matching those in the .bim file).
+\code{keep} and \code{remove} can take one of three
+formats:
+\enumerate{
+\item A logical vector indicating which indivduals to keep/remove,
+\item A \code{data.frame} with two columns giving the FID and IID of the indivdiuals to keep/remove (matching those in the .fam file), or
+\item A character scalar giving the text file with the FID/IID.
+}
+
+Note that these files should not contain headers.
+
+\code{extract} and \code{exclude} can be of format type \strong{(1)} or \strong{(3)} describe above, or a character vector of SNP ids (matching those in the .bim file).
 }


### PR DESCRIPTION
`parseselect()` would fail if `keep` or `remove` were data frame-like objects like a `tibble` or `data.table`. It now checks that `keep`/`remove` inherit the `data.frame` class and then coerces them to `data.frame`s with `as.data.frame()`. I also went ahead and updated the documentation to include some previously undocumented function parameters and return object list items.

Also added another condition (`file.exists()`) when assuming `extract`/`exclude`/`keep`/`remove` are file paths.